### PR TITLE
 Fix taxes by allowing a higher count in hscan in datastore

### DIFF
--- a/library/Datastore.nucleus.js
+++ b/library/Datastore.nucleus.js
@@ -1050,7 +1050,7 @@ class NucleusDatastore extends NucleusDeferredClassProxy {
         const datastoreRequestList = fieldNameList
           .map((fieldName) => {
 
-            return ['HSCAN', itemKey, 0, 'MATCH', `${fieldName}*`];
+            return ['HSCAN', itemKey, 0, 'MATCH', `${fieldName}*`, 'COUNT', 1000];
           });
 
         return this.$$server.multi(datastoreRequestList).execAsync()

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@idex/nucleus.core",
   "version": "0.10.5",
   "description": "A flexible library to implement a distributed micro-service(-like) architecture in NodeJS.",
+  "scripts": {
+    "test": "mocha tests"
+  },
   "keywords": [
     "architecture",
     "cms",


### PR DESCRIPTION
https://sofdesk.atlassian.net/browse/ROOF-779

Basically, hscan default count was too low to fetch all data (10) and returned partial data. By putting 1000 as count we could have approximately 30 taxes without problem.